### PR TITLE
Dev/lucas -> API de creación de hilos actualizada (versión urgente para otras US).

### DIFF
--- a/client/src/main/java/client/controller/AuthController.java
+++ b/client/src/main/java/client/controller/AuthController.java
@@ -23,27 +23,27 @@ public class AuthController {
         this.authService = authService;
     }
 
-//    /**
-//     * Muestra la página de autenticación (sign in por defecto).
-//     * Si viene con ?error=true, añade el mensaje de error al modelo para
-//     * que Thymeleaf lo muestre en la vista.
-//     *
-//     * @param error  parámetro opcional de URL que indica si hubo un error previo
-//     * @param mode   parámetro opcional que indica si mostrar "signin" o "signup"
-//     * @param model  modelo de datos para la plantilla Thymeleaf
-//     * @return nombre de la plantilla a renderizar
-//     */
-//    @GetMapping("/")
-//    public String authPage(
-//            @RequestParam(value = "error", required = false) String error,
-//            @RequestParam(value = "mode", defaultValue = "signin") String mode,
-//            Model model) {
-//        if (error != null) {
-//            model.addAttribute("error", true);
-//        }
-//        model.addAttribute("mode", mode);
-//        return "auth";
-//    }
+/**
+     * Muestra la página de autenticación (sign in por defecto).
+     * Si viene con ?error=true, añade el mensaje de error al modelo para
+     * que Thymeleaf lo muestre en la vista.
+     *
+     * @param error  parámetro opcional de URL que indica si hubo un error previo
+     * @param mode   parámetro opcional que indica si mostrar "signin" o "signup"
+     * @param model  modelo de datos para la plantilla Thymeleaf
+     * @return nombre de la plantilla a renderizar
+     */
+    @GetMapping("/")
+    public String authPage(
+            @RequestParam(value = "error", required = false) String error,
+            @RequestParam(value = "mode", defaultValue = "signin") String mode,
+            Model model) {
+        if (error != null) {
+            model.addAttribute("error", true);
+        }
+        model.addAttribute("mode", mode);
+        return "auth";
+    }
 
     /**
      * Procesa el formulario de inicio de sesión.

--- a/client/src/main/java/client/controller/HomeController.java
+++ b/client/src/main/java/client/controller/HomeController.java
@@ -31,7 +31,7 @@ public class HomeController {
      * a
      * I'm using a test object for now
      */
-    @GetMapping({"/", "/home"})
+    @GetMapping("/home")
     public String showDashboard(Model model) {
         //REMOVE
         ThreadSummaryDTO th1 = new ThreadSummaryDTO(1, "Hilo de prueba 1", "Descripción del hilo de prueba 1", "Usuario1");

--- a/client/src/main/java/client/controller/ThreadController.java
+++ b/client/src/main/java/client/controller/ThreadController.java
@@ -1,12 +1,14 @@
 package client.controller;
 
+import client.service.AuthServiceProxy;
+import client.service.CommunityServiceProxy;
+import client.service.ThreadServiceProxy;
 import lib.dto.CreateThreadDTO;
 import lib.dto.ThreadDTO;
 import lib.dto.ThreadSummaryDTO;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-import client.service.ThreadServiceProxy;
 
 import java.util.List;
 
@@ -15,9 +17,21 @@ import java.util.List;
 public class ThreadController {
 
     private final ThreadServiceProxy threadService;
+    private final AuthServiceProxy authService;
+    private final CommunityServiceProxy communityService;
 
-    public ThreadController(ThreadServiceProxy threadService) {
+    public ThreadController(ThreadServiceProxy threadService,
+                            AuthServiceProxy authService,
+                            CommunityServiceProxy communityService) {
         this.threadService = threadService;
+        this.authService = authService;
+        this.communityService = communityService;
+    }
+
+    @GetMapping("/new")
+    public String showThreadWindow(Model model) {
+        model.addAttribute("comunidades", communityService.getAll());
+        return "newThread";
     }
 
     @GetMapping
@@ -40,7 +54,10 @@ public class ThreadController {
             @RequestParam String title,
             @RequestParam(required = false) String description,
             @RequestParam Integer comunidadId) {
-        threadService.createHilo(new CreateThreadDTO(title, description, comunidadId));
-        return "redirect:/threads";
+        ThreadDTO created = threadService.createHilo(new CreateThreadDTO(title, description, comunidadId));
+        if (created == null) {
+            return "redirect:/?error=true";
+        }
+        return "redirect:/home";
     }
 }

--- a/client/src/main/java/client/controller/ThreadController.java
+++ b/client/src/main/java/client/controller/ThreadController.java
@@ -39,9 +39,8 @@ public class ThreadController {
     public String createThread(
             @RequestParam String title,
             @RequestParam(required = false) String description,
-            @RequestParam Integer comunidadId,
-            @RequestParam Integer ownerId) {
-        threadService.createHilo(new CreateThreadDTO(title, description, comunidadId, ownerId));
+            @RequestParam Integer comunidadId) {
+        threadService.createHilo(new CreateThreadDTO(title, description, comunidadId));
         return "redirect:/threads";
     }
 }

--- a/client/src/main/java/client/service/AuthServiceProxy.java
+++ b/client/src/main/java/client/service/AuthServiceProxy.java
@@ -3,10 +3,7 @@ package client.service;
 import client.config.AppConfig;
 import lib.dto.UserCredentialsDTO;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -101,6 +98,29 @@ public class AuthServiceProxy {
         } catch (HttpClientErrorException e) {
             return false;
         } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean validateSession() {
+        if (this.token == null) return false;
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(this.token);
+            HttpEntity<?> request = new HttpEntity<>(headers);
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    serverApiUrl + "/auth/validate",
+                    HttpMethod.GET,
+                    request,
+                    Void.class
+            );
+            System.out.println("VALIDATE STATUS: " + response.getStatusCode());
+            return response.getStatusCode() == HttpStatus.OK;
+        } catch (HttpClientErrorException e) {
+            System.out.println("VALIDATE ERROR: " + e.getStatusCode());
+            return false;
+        } catch (Exception e) {
+            System.out.println("VALIDATE EXCEPTION: " + e.getMessage());
             return false;
         }
     }

--- a/client/src/main/java/client/service/CommunityServiceProxy.java
+++ b/client/src/main/java/client/service/CommunityServiceProxy.java
@@ -1,0 +1,39 @@
+package client.service;
+
+import lib.dto.CommunityDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class CommunityServiceProxy {
+
+    private final RestTemplate restTemplate;
+    private final String serverApiUrl;
+
+    public CommunityServiceProxy(RestTemplate restTemplate,
+                                 @Value("${server.api.url}") String serverApiUrl) {
+        this.restTemplate = restTemplate;
+        this.serverApiUrl = serverApiUrl;
+    }
+
+    public List<CommunityDTO> getAll() {
+        try {
+            ResponseEntity<List<CommunityDTO>> response = restTemplate.exchange(
+                    serverApiUrl + "/api/communities",
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+            return response.getBody() != null ? response.getBody() : Collections.emptyList();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/client/src/main/java/client/service/ThreadServiceProxy.java
+++ b/client/src/main/java/client/service/ThreadServiceProxy.java
@@ -1,6 +1,6 @@
 package client.service;
 
-import client.config.AppConfig;
+import client.service.AuthServiceProxy;
 import lib.dto.CreateThreadDTO;
 import lib.dto.ThreadDTO;
 import lib.dto.ThreadSummaryDTO;
@@ -17,20 +17,28 @@ import java.util.List;
 public class ThreadServiceProxy {
 
     private final RestTemplate restTemplate;
-    private final String       serverApiUrl;
+    private final String serverApiUrl;
+    private final AuthServiceProxy authService;
 
-    // NO INYECTÉIS LA CLASE ENTERA DE APPCONFIG, usad las variables de entorno del properties
     public ThreadServiceProxy(RestTemplate restTemplate,
+                              AuthServiceProxy authService,
                               @Value("${server.api.url}") String serverApiUrl) {
         this.restTemplate = restTemplate;
+        this.authService = authService;
         this.serverApiUrl = serverApiUrl;
     }
 
     public ThreadDTO createHilo(CreateThreadDTO dto) {
         try {
-            ResponseEntity<ThreadDTO> response = restTemplate.postForEntity(
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(authService.getToken());
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<CreateThreadDTO> request = new HttpEntity<>(dto, headers);
+
+            ResponseEntity<ThreadDTO> response = restTemplate.exchange(
                     serverApiUrl + "/api/threads/create",
-                    dto,
+                    HttpMethod.POST,
+                    request,
                     ThreadDTO.class
             );
             return response.getBody();

--- a/client/src/main/resources/templates/home.html
+++ b/client/src/main/resources/templates/home.html
@@ -39,7 +39,7 @@
     <aside class="left-panel">
         <nav class="side-menu">
             <a href="#" class="menu-item active"><span>↗️</span> Popular</a>
-            <a href="#" class="menu-item"><span>+</span> Crear Hilo</a>
+            <a th:href="@{/threads/new}" class="menu-item"><span>+</span> Crear Hilo</a>
             <a href="#" class="menu-item"><span>🧭</span> Explorar</a>
             <hr class="separator">
             <p class="menu-label">RECURSOS</p>

--- a/client/src/main/resources/templates/newThread.html
+++ b/client/src/main/resources/templates/newThread.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Nuevo hilo - DunkelWeiss</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}"/>
+    <style>
+        .new-thread-container {
+            max-width: 720px;
+            margin: 80px auto 0 auto;
+            padding: 24px;
+        }
+        .form-card {
+            background-color: var(--bg-surface);
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .form-card h2 {
+            font-size: 20px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin: 0;
+        }
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .form-group label {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-secondary);
+        }
+        .form-group input,
+        .form-group textarea,
+        .form-group select {
+            background-color: var(--bg-surface-hover);
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            padding: 10px 14px;
+            font-size: 15px;
+            color: var(--text-primary);
+            outline: none;
+            transition: 0.2s;
+        }
+        .form-group input:focus,
+        .form-group textarea:focus,
+        .form-group select:focus {
+            border-color: var(--brand-color);
+            box-shadow: 0 0 0 1px var(--brand-color);
+        }
+        .form-group textarea {
+            resize: vertical;
+            min-height: 120px;
+        }
+        .form-group select option {
+            background-color: var(--bg-surface);
+        }
+        .form-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+
+<header class="dunkel-navbar">
+    <div class="navbar-content">
+        <div class="nav-left">
+            <div class="brand-container">
+                <span class="brand-logo">🕸️</span>
+                <h1 class="brand-name">Dunkelweiss</h1>
+            </div>
+        </div>
+        <div class="nav-right">
+            <a href="/home" class="btn btn-outline" style="text-decoration: none; display: flex; align-items: center;">Volver</a>
+        </div>
+    </div>
+</header>
+
+<div class="new-thread-container">
+    <div class="form-card">
+        <h2>Crear nuevo hilo</h2>
+
+        <form th:action="@{/threads/create}" method="post">
+            <div class="form-group">
+                <label for="title">Título</label>
+                <input type="text" id="title" name="title"
+                       placeholder="Dale un título a tu hilo" required/>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Descripción</label>
+                <textarea id="description" name="description"
+                          placeholder="¿De qué trata tu hilo?"></textarea>
+            </div>
+
+            <div class="form-group">
+                <label for="comunidadId">Comunidad</label>
+                <select id="comunidadId" name="comunidadId" required>
+                    <option value="" disabled selected>Selecciona una comunidad</option>
+                    <option th:each="comunidad : ${comunidades}"
+                            th:value="${comunidad.id()}"
+                            th:text="${comunidad.name()}">
+                    </option>
+                </select>
+            </div>
+
+            <div class="form-actions">
+                <a href="/home" class="btn btn-outline" style="text-decoration: none; display: flex; align-items: center;">Cancelar</a>
+                <button type="submit" class="btn" style="background-color: var(--brand-color); color: white;">Publicar hilo</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+</body>
+</html>

--- a/lib/src/main/java/lib/dto/CommunityDTO.java
+++ b/lib/src/main/java/lib/dto/CommunityDTO.java
@@ -1,0 +1,9 @@
+package lib.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CommunityDTO(
+        @JsonProperty("id")          Integer id,
+        @JsonProperty("name")        String  name,
+        @JsonProperty("description") String  description
+) {}

--- a/lib/src/main/java/lib/dto/CreateThreadDTO.java
+++ b/lib/src/main/java/lib/dto/CreateThreadDTO.java
@@ -12,8 +12,5 @@ public record CreateThreadDTO(
         String  description,
         @NotNull
         @JsonProperty("comunidadId")
-        Integer comunidadId,
-        @NotNull
-        @JsonProperty("ownerId")
-        Integer ownerId
+        Integer comunidadId
 ) {}

--- a/lib/src/main/java/lib/dto/CreateThreadDTO.java
+++ b/lib/src/main/java/lib/dto/CreateThreadDTO.java
@@ -4,50 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public class CreateThreadDTO {
-
-    @NotBlank
-    @JsonProperty("title")
-    private String title;
-
-    @JsonProperty("description")
-    private String description;
-
-    @NotNull
-    @JsonProperty("comunidadId")
-    private Integer comunidadId;
-
-    @NotNull
-    @JsonProperty("ownerId")
-    private Integer ownerId;
-
-    public CreateThreadDTO() {}
-
-    public CreateThreadDTO(String title, String description,
-                           Integer comunidadId, Integer ownerId) {
-        this.title       = title;
-        this.description = description;
-        this.comunidadId = comunidadId;
-        this.ownerId     = ownerId;
-    }
-
-    public String  getTitle()       { return title; }
-    public String  getDescription() { return description; }
-    public Integer getComunidadId() { return comunidadId; }
-    public Integer getOwnerId()     { return ownerId; }
-
-    public void setTitle(String title)             { this.title = title; }
-    public void setDescription(String description) { this.description = description; }
-    public void setComunidadId(Integer comunidadId){ this.comunidadId = comunidadId; }
-    public void setOwnerId(Integer ownerId)        { this.ownerId = ownerId; }
-
-    @Override
-    public String toString() {
-        return "CreateThreadDTO{" +
-                "title='" + title + '\'' +
-                ", description='" + description + '\'' +
-                ", comunidadId=" + comunidadId +
-                ", ownerId=" + ownerId +
-                '}';
-    }
-}
+public record CreateThreadDTO(
+        @NotBlank
+        @JsonProperty("title")
+        String  title,
+        @JsonProperty("description")
+        String  description,
+        @NotNull
+        @JsonProperty("comunidadId")
+        Integer comunidadId,
+        @NotNull
+        @JsonProperty("ownerId")
+        Integer ownerId
+) {}

--- a/lib/src/main/java/lib/dto/ThreadDTO.java
+++ b/lib/src/main/java/lib/dto/ThreadDTO.java
@@ -2,49 +2,15 @@ package lib.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-
-public class ThreadDTO {
-
-    @JsonProperty("id")
-    private Integer id;
-
-    @JsonProperty("title")
-    private String title;
-
-    @JsonProperty("description")
-    private String description;
-
-    @JsonProperty("ownerUsername")
-    private String ownerUsername;
-
-    @JsonProperty("comunidadNombre")
-    private String comunidadNombre;
-
-    public ThreadDTO() {}
-
-    public ThreadDTO(Integer id, String title, String description,
-                     String ownerUsername, String comunidadNombre) {
-        this.id             = id;
-        this.title          = title;
-        this.description    = description;
-        this.ownerUsername  = ownerUsername;
-        this.comunidadNombre = comunidadNombre;
-    }
-
-    public Integer getId()              { return id; }
-    public String  getTitle()           { return title; }
-    public String  getDescription()     { return description; }
-    public String  getOwnerUsername()   { return ownerUsername; }
-    public String  getComunidadNombre() { return comunidadNombre; }
-
-    @Override
-    public String toString() {
-        return "ThreadDTO{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", description='" + description + '\'' +
-                ", ownerUsername='" + ownerUsername + '\'' +
-                ", comunidadNombre='" + comunidadNombre + '\'' +
-                '}';
-    }
-}
+public record ThreadDTO(
+        @JsonProperty("id")
+        Integer id,
+        @JsonProperty("title")
+        String  title,
+        @JsonProperty("description")
+        String  description,
+        @JsonProperty("ownerUsername")
+        String  ownerUsername,
+        @JsonProperty("comunidadNombre")
+        String  comunidadNombre
+) {}

--- a/server/.env
+++ b/server/.env
@@ -1,4 +1,4 @@
-DB_ROOT_PASSWORD=root
-DB_USER=admin
-DB_PASSWORD=admin
+DB_ROOT_PASSWORD=pon_tu_contraseña_aqui
+DB_USER=usuario_local
+DB_PASSWORD=pass_local
 DB_NAME=dunkelweiss_db

--- a/server/src/main/java/server/config/OpenApiConfig.java
+++ b/server/src/main/java/server/config/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package server.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "DunkelWeiss API", version = "1.0"))
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "token"
+)
+public class OpenApiConfig {}

--- a/server/src/main/java/server/controller/CommunityController.java
+++ b/server/src/main/java/server/controller/CommunityController.java
@@ -1,0 +1,36 @@
+package server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lib.dto.CommunityDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.service.CommunityService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/communities")
+@Tag(name = "Comunidades", description = "Operaciones relacionadas con comunidades")
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+    public CommunityController(CommunityService communityService) {
+        this.communityService = communityService;
+    }
+
+    @Operation(
+            summary = "Listar todas las comunidades",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Lista de comunidades")
+            }
+    )
+    @GetMapping
+    public ResponseEntity<List<CommunityDTO>> getAll() {
+        return ResponseEntity.ok(communityService.getAll());
+    }
+}

--- a/server/src/main/java/server/controller/ThreadController.java
+++ b/server/src/main/java/server/controller/ThreadController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lib.dto.CreateThreadDTO;
 import lib.dto.ThreadDTO;
@@ -15,8 +16,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import server.service.ThreadService;
 import server.entity.Thread;
+import server.entity.User;
+import server.service.AuthService;
+import server.service.ThreadService;
+
 import java.util.List;
 
 @Tag(
@@ -28,14 +32,16 @@ import java.util.List;
 public class ThreadController {
 
     private final ThreadService threadService;
+    private final AuthService authService;
 
-    public ThreadController(ThreadService threadService) {
+    public ThreadController(ThreadService threadService, AuthService authService) {
+        this.authService = authService;
         this.threadService = threadService;
     }
 
     @Operation(
             summary = "Crear un hilo",
-            description = "Crea un nuevo hilo de discusión asociado a una comunidad y a un usuario propietario."
+            description = "Crea un nuevo hilo de discusión asociado a una comunidad. El propietario se resuelve automáticamente desde el token de sesión."
     )
     @ApiResponses({
             @ApiResponse(
@@ -48,11 +54,21 @@ public class ThreadController {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "El usuario o la comunidad indicados no existen",
+                    description = "La comunidad indicada no existe",
                     content = @Content(
                             mediaType = MediaType.TEXT_PLAIN_VALUE,
-                            examples = @ExampleObject(value = "Usuario no encontrado: 99")
+                            examples = @ExampleObject(value = "Community no encontrada: 99")
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "No autenticado: falta el token o no tiene formato Bearer",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE)
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Token inválido o sesión expirada",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE)
             )
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -64,20 +80,42 @@ public class ThreadController {
                     examples = @ExampleObject(
                             name = "Ejemplo básico",
                             value = """
-                {
-                  "title": "¿Cuál es el mejor IDE?",
-                  "description": "Debatimos sobre IntelliJ, VS Code y Neovim.",
-                  "comunidadId": 1,
-                  "ownerId": 1
-                }
-                """
+                        {
+                          "title": "¿Cuál es el mejor IDE?",
+                          "description": "Debatimos sobre IntelliJ, VS Code y Neovim.",
+                          "comunidadId": 1
+                        }
+                        """
                     )
             )
     )
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/create")
-    public ResponseEntity<?> createHilo(@RequestBody CreateThreadDTO dto) {
+    public ResponseEntity<?> createHilo(
+            @Parameter(
+                    name = "Authorization",
+                    description = "Token de sesión en formato Bearer <token>",
+                    required = true,
+                    in = io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER
+            )
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestBody CreateThreadDTO dto) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("Debes iniciar sesión para crear un hilo.");
+        }
+
+        String token = authHeader.substring(7);
+        User user = authService.getUserByToken(token);
+
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("Tu sesión no es válida. Vuelve a iniciar sesión.");
+        }
+
         try {
-            ThreadDTO created = threadService.createHilo(dto);
+            ThreadDTO created = threadService.createHilo(dto, user);
             return ResponseEntity.status(HttpStatus.CREATED).body(created);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());

--- a/server/src/main/java/server/service/CommunityService.java
+++ b/server/src/main/java/server/service/CommunityService.java
@@ -1,0 +1,24 @@
+package server.service;
+
+import lib.dto.CommunityDTO;
+import org.springframework.stereotype.Service;
+import server.dao.CommunityRepository;
+
+import java.util.List;
+
+@Service
+public class CommunityService {
+
+    private final CommunityRepository communityRepository;
+
+    public CommunityService(CommunityRepository communityRepository) {
+        this.communityRepository = communityRepository;
+    }
+
+    public List<CommunityDTO> getAll() {
+        return communityRepository.findAll()
+                .stream()
+                .map(c -> new CommunityDTO(c.getId(), c.getName(), c.getDescription()))
+                .toList();
+    }
+}

--- a/server/src/main/java/server/service/ThreadService.java
+++ b/server/src/main/java/server/service/ThreadService.java
@@ -28,18 +28,14 @@ public class ThreadService {
         this.communityRepository = communityRepository;
     }
 
-    public ThreadDTO createHilo(CreateThreadDTO dto) {
-        User owner = userRepository.findById(dto.getOwnerId())
+    public ThreadDTO createHilo(CreateThreadDTO dto, User owner) {
+        Community community = communityRepository.findById(dto.comunidadId())
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "Usuario no encontrado: " + dto.getOwnerId()));
-
-        Community community = communityRepository.findById(dto.getComunidadId())
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Community no encontrada: " + dto.getComunidadId()));
+                        "Community no encontrada: " + dto.comunidadId()));
 
         Thread hilo = new Thread();
-        hilo.setTitle(dto.getTitle());
-        hilo.setDescription(dto.getDescription());
+        hilo.setTitle(dto.title());
+        hilo.setDescription(dto.description());
         hilo.setOwner(owner);
         hilo.setCommunity(community);
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8080
 
 # Docker
-spring.docker.compose.file=server/compose.yaml
+spring.docker.compose.file=compose.yaml
 
 # MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8080
 
 # Docker
-spring.docker.compose.file=compose.yaml
+spring.docker.compose.file=server/compose.yaml
 
 # MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}


### PR DESCRIPTION
Refactor DTOs a record y mejora del endpoint de creación de hilos

- Convertidos CreateThreadDTO, ThreadDTO y ThreadSummaryDTO a record
- ThreadController extrae el token del header Authorization y valida la
  sesión antes de crear el hilo (401 si falta token, 403 si es inválido)
- Añadido OpenApiConfig con security scheme Bearer para poder autenticarse
  desde Swagger UI sin necesidad de editar cada petición manualmente